### PR TITLE
Create export-licensing-policies.sh

### DIFF
--- a/bash/export-licensing-policies.sh
+++ b/bash/export-licensing-policies.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+  echo "No api key in argument provided."
+else
+  response=$(curl -s -X GET 'https://app.fossa.com/api/policies' --header "Authorization: Bearer $1")
+
+  if [ $? -eq 0 ]; then
+    parsed_response=$(echo "$response" | jq --compact-output '.[] | select(.type == "LICENSING") | { policyId: .latestVersion.policyId, title: .title, createdAt: .latestVersion.createdAt, updatedAt: .updatedAt  }')
+
+    echo "${parsed_response}" | while IFS= read -r line; do
+
+      policyId=$(echo "${line}" | jq -r '.policyId')
+      title=$(echo "${line}" | jq -r '.title' | sed 's/\///g')
+
+      policy_response=$(curl -s -X GET "https://app.fossa.com/api/policies/${policyId}" --header "Authorization: Bearer $1")
+
+      parsed_policy_response=$(echo "$policy_response" | jq '.rules | group_by(.type) | .[] | { type: .[0].type, licenseId: map(.licenseId) | sort }')
+      echo "${parsed_policy_response}" > "policyId-${policyId}-policy-${title}.json"
+    done
+  else
+    echo "Oh no. An error occurred while executing the policies GET request."
+  fi
+fi


### PR DESCRIPTION
PR to add a bash script which can export the licensing policies. The output is a set of policies in json format, which looks something like this:

```
{
  "type": "approved_license",
  "licenseId": [
    "AFL-3.0",
    "Apache-1.1",
    "Apache-2.0",
    "BSD-1-Clause",
    "BSD-2-Clause",
    "BSD-3-Clause",
    "BSD-4-Clause",
    "BSL-1.0",
    "CC-BY-1.0",
    "ISC",
    "MIT",
    "NCSA",
    "PDDL-1.0",
    "PHP-3.0",
    "PHP-3.01",
    "Python-2.0",
    "UPL-1.0",
    "Unlicense",
    "W3C",
    "W3C-19980720",
    "W3C-20150513",
    "WTFPL",
    "Xnet",
    "ZPL-1.1",
    "ZPL-2.0",
    "ZPL-2.1",
    "Zlib",
    "zlib-acknowledgement"
  ]
}
{
  "type": "denied_license",
  "licenseId": [
    "AGPL-1.0",
    "AGPL-3.0-only",
    "AGPL-3.0-or-later",
    "CPOL-1.02",
    "GPL-2.0-only",
    "GPL-2.0-or-later",
    "GPL-3.0-only",
    "GPL-3.0-or-later",
    "LGPL-3.0-only",
    "LGPL-3.0-or-later",
    "OSL-1.0",
    "OSL-1.1",
    "OSL-2.0",
    "OSL-2.1",
    "OSL-3.0",
    "RPL-1.1",
    "RPL-1.5",
    "SimPL-2.0",
    "Sleepycat",
    "unknown"
  ]
}
{
  "type": "flagged_license",
  "licenseId": [
    "Artistic-1.0",
    "Artistic-2.0",
    "CDDL-1.0",
    "CDDL-1.1",
    "CPAL-1.0",
    "CPL-1.0",
    "ClArtistic",
    "EPL-1.0",
    "EPL-2.0",
    "GPL-2.0-with-classpath-exception",
    "GPL-3.0-with-GCC-exception",
    "LGPL-2.0-only",
    "LGPL-2.0-or-later",
    "LGPL-2.1-only",
    "LGPL-2.1-or-later",
    "MPL-1.1",
    "MPL-2.0",
    "MS-PL",
    "MS-RL",
    "Ruby"
  ]
}
```

In order to run this script, make sure to have a full access token and provide it as the first argument to the script.