### PR TITLE
Add useful script to generate release group report

### DIFF
--- a/APIs/walkthroughs/release-group-report-generation/README.md
+++ b/APIs/walkthroughs/release-group-report-generation/README.md
@@ -1,0 +1,26 @@
+## How to generate a release group report
+
+The purpose of this script is to help FOSSA users generate a release group from our [Release Group Report API](https://docs.fossa.com/reference/post_project-group-groupid-release-releaseid-attribution-format).
+This is simply an example of how to use it. In this example, the release group report is downloaded to _the user's_ local machine.
+
+### Prerequisites
+
+#### Local build environment
+- Have node installed
+- Run `npm install`
+
+#### FOSSA report requirements
+
+- Review our release group report API [here](https://docs.fossa.com/reference/post_project-group-groupid-release-releaseid-attribution-format).
+- Grab your full access token from the FOSSA organization settings, if you don't have it already.
+- Set your `FOSSA_API_KEY` as an environment variable.
+- In the FOSSA UI, click on the release group of interest > click the releases tab
+  - Notice the URL. It should look something like this `https://app.fossa.com/projects/group/<group id>/releases/<release id>` 
+  - Take note of the group id and release id.
+- Decide on the report format: HTML, PDF, CSV, TXT, SPDX or SPDX_JSON.
+- Decide which fields you'd want to include in the report.
+  - Go to `https://app.fossa.com/projects/group/<group id>/export` to see the options.
+- Modify the script with the appropriate query parameters. 
+- Run the script properly. 
+  - For example,  `node release-group-report-generation.js --project-group 123 --release-id 456 --format TXT --fossa-api-key $FOSSA_API_KEY`
+  - Run `node release-group-report-generation.js --help` for help.

--- a/APIs/walkthroughs/release-group-report-generation/package-lock.json
+++ b/APIs/walkthroughs/release-group-report-generation/package-lock.json
@@ -1,0 +1,102 @@
+{
+  "name": "release-group-report-generation",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "axios": "^1.4.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    }
+  }
+}

--- a/APIs/walkthroughs/release-group-report-generation/package.json
+++ b/APIs/walkthroughs/release-group-report-generation/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "axios": "^1.4.0"
+  }
+}

--- a/APIs/walkthroughs/release-group-report-generation/release-group-report-generation.js
+++ b/APIs/walkthroughs/release-group-report-generation/release-group-report-generation.js
@@ -175,4 +175,3 @@ function main() {
 
 // Run the script
 main();
-n

--- a/APIs/walkthroughs/release-group-report-generation/release-group-report-generation.js
+++ b/APIs/walkthroughs/release-group-report-generation/release-group-report-generation.js
@@ -1,0 +1,178 @@
+const axios = require('axios');
+const querystring = require('querystring');
+const fs = require('fs');
+const https = require('https');
+
+// Function to submit the release group generation request
+// Note modify the query params in this function to your needs
+async function submitRequest(projectGroup, releaseID, format, bearerToken) {
+  try {
+    const queryParams = querystring.stringify({
+      includeDeepDependencies: true,
+      includeDirectDependencies: true,
+      includeLicenseList: true,
+      includeLicenseScan: true,
+      includeProjectLicense: true,
+      includeCopyrightList: true,
+      includeFileMatches: true,
+      includeVulnerabilities: true,
+      includeDependencySummary: true,
+      includeLicenseHeaders: true,
+    });
+
+    const url = `https://app.fossa.com/api/project_group/${projectGroup}/release/${releaseID}/attribution/${format}?${queryParams}`;
+
+    const response = await axios.post(url, null, {
+      headers: {
+        'Authorization': `Bearer ${bearerToken}`,
+        'Accept': 'application/json',
+      },
+    });
+
+    const taskId = response.data.taskId;
+    console.log('POST request succeeded. Task ID:', taskId);
+
+    // Check the status and get the S3 URL
+    await checkStatus(taskId, bearerToken, format);
+  } catch (error) {
+    console.error('Error submitting POST request:', error.response.data);
+  }
+}
+
+// Function to check the status and get the S3 URL
+async function checkStatus(taskId, bearerToken, format) {
+  try {
+    const response = await axios.get(`https://app.fossa.com/api/project_group/attribution/${taskId}`, {
+      headers: {
+        'Authorization': `Bearer ${bearerToken}`,
+      },
+    });
+
+    const status = response.data.status;
+    console.log('Status:', status);
+
+    if (status === 'SUCCEEDED') {
+      const s3URL = response.data.url;
+      console.log('S3 URL:', s3URL);
+
+      // Generate a timestamp in ISO format
+      const timestamp = new Date().toISOString().replace(/:/g, '-');
+      const releaseGroupFileName = `release-group-report-${timestamp}.${getOutputFormat(format)}`;
+
+      // Download from S3
+      downloadFromS3(s3URL, releaseGroupFileName)
+        .then(() => {
+          console.log('Download completed successfully!');
+        })
+        .catch((error) => {
+          console.error('Error downloading file:', error);
+        });
+    } else if (status === 'FAILED') {
+      console.error('Task failed. Unable to generate the report.');
+    } else {
+      // Retry after a certain interval or handle the pending status
+      console.log('Task is still pending. Retrying after an interval...');
+      setTimeout(() => checkStatus(taskId, bearerToken, format), 5000);
+    }
+  } catch (error) {
+    console.error('Error with report generation:', error);
+  }
+}
+
+// Function to download report from S3
+function downloadFromS3(url, destinationPath) {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(destinationPath);
+
+    https.get(url, (response) => {
+      response.pipe(file);
+
+      file.on('finish', () => {
+        file.close();
+        resolve();
+      });
+    }).on('error', (error) => {
+      fs.unlink(destinationPath, () => {
+        reject(error);
+      });
+    });
+  });
+}
+
+// Get the output format based on the given format
+function getOutputFormat(format) {
+  if (format === 'SPDX_JSON') {
+    return 'json';
+  }
+
+  return format.toLowerCase();
+}
+
+// Parse command-line arguments using flags
+function parseFlags(args) {
+  const flags = {};
+  let currentFlag = null;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg.startsWith('--')) {
+      currentFlag = arg.slice(2);
+      flags[currentFlag] = true;
+    } else if (currentFlag) {
+      flags[currentFlag] = arg;
+      currentFlag = null;
+    }
+  }
+
+  return flags;
+}
+
+// Validate required flags
+function validateFlags(flags) {
+  const requiredFlags = ['project-group', 'release-id', 'format', 'fossa-api-key'];
+  const missingFlags = requiredFlags.filter((flag) => !flags[flag]);
+
+  if (missingFlags.length > 0) {
+    console.error('Missing required flags:', missingFlags.join(', '));
+    return false;
+  }
+
+  return true;
+}
+
+// Display help message
+function displayHelp() {
+  console.log('Usage: node release-group-report-generation.js --project-group <project-group-id> --release-id <release-id> --format <format> --fossa-api-key <fossa-api-key>');
+  console.log('');
+  console.log('Required flags:');
+  console.log('  --project-group    <project-group-id>  Project Group ID');
+  console.log('  --release-id       <release-id>        Release ID');
+  console.log('  --format           <format>            Format of the release group report (e.g. HTML, CSV, MD, PDF, TXT, SPDX, SPDX_JSON)');
+  console.log('  --fossa-api-key    <fossa-api-key>     FOSSA full access token for authentication');
+  console.log('');
+  console.log('Example:');
+  console.log('  node release-group-report-generation.js --project-group 123 --release-id 456 --format HTML --fossa-api-key abc123');
+}
+
+// Main function
+function main() {
+  const args = process.argv.slice(2);
+  const flags = parseFlags(args);
+
+  if (flags['--help']) {
+    displayHelp();
+    return;
+  }
+
+  if (!validateFlags(flags)) {
+    displayHelp();
+    return;
+  }
+
+  submitRequest(flags['project-group'], flags['release-id'], flags['format'], flags['fossa-api-key']);
+}
+
+// Run the script
+main();
+n


### PR DESCRIPTION
PR to help users generate and download reports to their machine. Can be modified and used in other ways such as syncing report to some S3 bucket, etc, but want to make sure the base case of getting it downloaded locally is covered. Iterations of this have been shared to some of our users.