### PR TITLE
Create fossa-github-org-analysis.sh

### DIFF
--- a/bash/fossa-github-org-analysis.sh
+++ b/bash/fossa-github-org-analysis.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+org_name="insert-gh-org-name-here"
+token="call-gh-pat-here"
+page=1
+
+while true; do
+  repos=$(curl -s -H "Authorization: Bearer $token" "https://api.github.com/orgs/$org_name/repos?per_page=100&page=$page&type=private" | jq -r '.[].name')
+  echo "Private repositories identified: \n $repos"
+
+  # Create debug directory
+  TIMESTAMP=$(date +"%m-%d-%Y")
+  DEBUG_DIR=debug-files-$TIMESTAMP
+  mkdir $DEBUG_DIR
+
+  for repo in $repos; do
+    echo "Cloning and analyzing private repo: $repo"
+
+    git clone "https://github.com/$org_name/$repo.git" "$repo"
+    if [ $? -eq 0 ]; then
+      echo "Clone of $repo successful"
+    else
+      echo "Clone of $repo failed"
+      exit 1
+    fi
+
+    # Run FOSSA Analysis
+    fossa analyze $repo --fossa-api-key $FOSSA_API_KEY --debug
+    # Probably need to refactor this if you need to use any flags
+
+    # Check the exit code of the fossa analyze command
+    if [ $? -ne 0 ]; then
+      echo "FOSSA analysis failed"
+      # Rename and move the debug and telemetry files
+      mv fossa.debug.json.gz "failed-$repo-fossa.debug.json.gz"
+      mv "failed-$repo-fossa.debug.json.gz" $DEBUG_DIR
+      mv fossa.telemetry.json "failed-$repo-fossa.telemetry.json"
+      mv "failed-$repo-fossa.telemetry.json" $DEBUG_DIR
+    else
+      echo "FOSSA analysis succeeded for $repo"
+      mv fossa.debug.json.gz "success-$repo-fossa.debug.json.gz"
+      mv "success-$repo-fossa.debug.json.gz" $DEBUG_DIR
+      mv fossa.telemetry.json "success-$repo-fossa.telemetry.json"
+      mv "success-$repo-fossa.telemetry.json" $DEBUG_DIR
+    fi
+
+    # Remove repository
+    rm -rf $repo
+  done
+
+  # Check if there are more pages
+  link_header=$(curl -I -s -H "Authorization: Bearer $token" "https://api.github.com/orgs/$org_name/repos?per_page=100&page=$page&type=private" | grep -i link)
+  if [[ $link_header =~ .*rel=\"next\".* ]]; then
+    ((page++))
+  else
+    break
+  fi
+done
+
+echo "FOSSA Bulk Analysis Complete. See Debug directory for any failed analysis runs."


### PR DESCRIPTION
Scrappy way to bulk analyze a bunch of repositories. This script attempts to paginate through PRIVATE repositories and scans them. All logs go through a timestamped debug directory.

Successful scans will appear in FOSSA Project Dashboard:
<img width="1423" alt="image" src="https://github.com/fossas/post_sales_scripts/assets/1427948/a78e86fa-9e97-4f6e-9e40-061d7719935b">

Debug logs are dumped like so:

<img width="939" alt="image" src="https://github.com/fossas/post_sales_scripts/assets/1427948/0eb14572-574c-4bf1-b781-0d6c8bcffcbe">


Notes: This was tested on a Mac
<img width="225" alt="image" src="https://github.com/fossas/post_sales_scripts/assets/1427948/6d599939-962b-46e4-849c-227c943675f1">

This was tested on a GitHub organization that doesn't include 1k+ repositories to paginate through. 
Parallelisation _can_ be included but not required at this time to get this merged. 😆 